### PR TITLE
chore/step43 corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'pnpm'
+      - name: Enable Corepack (pnpm from packageManager)
+        run: corepack enable
       - name: Install
         run: pnpm install --frozen-lockfile
       - name: Run tests
@@ -37,14 +36,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'pnpm'
+      - name: Enable Corepack (pnpm from packageManager)
+        run: corepack enable
       - name: Install
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
- **ci: trigger baseline artifact run**
- **step43: make web-smoke timing artifact robust**
- **ci: trigger baseline artifact run**
- **step43: fix workflow yaml and robust timing artifact**
- **step43: fix pnpm setup (remove duplicate cache)**
- **step43: use Corepack; remove pnpm/action-setup; keep artifact timing**
