### PR TITLE
chore/step43 corepack prepare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-      - name: Enable Corepack (pnpm from packageManager)
-        run: corepack enable
+
+      - name: Enable Corepack and prepare pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9 --activate
+          pnpm --version
+
       - name: Install
         run: pnpm install --frozen-lockfile
+
       - name: Run tests
         run: pnpm -w test
 
@@ -36,13 +43,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-      - name: Enable Corepack (pnpm from packageManager)
-        run: corepack enable
+
+      - name: Enable Corepack and prepare pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9 --activate
+          pnpm --version
+
       - name: Install
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
- **ci: trigger baseline artifact run**
- **step43: make web-smoke timing artifact robust**
- **ci: trigger baseline artifact run**
- **step43: fix workflow yaml and robust timing artifact**
- **step43: fix pnpm setup (remove duplicate cache)**
- **step43: use Corepack; remove pnpm/action-setup; keep artifact timing**
- **step43: corepack prepare pnpm@9 and verify before install**
