### PR TITLE
chore/step44 upload logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           exit 1
 
       # Measure build+boot+smoke and always write artifacts, even if smoke fails
+
       - name: Measure build+boot+smoke and save timing artifact
         if: always()
         shell: bash
@@ -125,6 +126,22 @@ jobs:
           name: web-smoke-timing-${{ github.run_id }}
           path: artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt
           if-no-files-found: error
+
+- name: Guardrail: warn on slow smoke
+  if: always()
+  shell: bash
+  run: |
+    TFILE="artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt"
+    if [ ! -f "$TFILE" ]; then
+      echo "::warning title=Smoke timing missing::$TFILE not found"
+      exit 0
+    fi
+    SECS="$(tr -d '\r\n' < "$TFILE")"
+    THRESHOLD="35"
+    if awk -v s="$SECS" -v t="$THRESHOLD" 'BEGIN{exit !(s+0>t+0)}'; then
+      echo "::warning title=Smoke timing regression::web-smoke took ${SECS}s (> ${THRESHOLD}s baseline×1.25)"
+    fi
+
 
       - name: Upload logs (server & smoke)
         if: always()


### PR DESCRIPTION
- **ci: trigger baseline artifact run**
- **step43: install pnpm via pnpm/action-setup without version; verify pnpm; keep artifact timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step43: run smoke via bash script instead of pnpm workspace script**
- **ci: trigger baseline artifact run**
- **step43: run smoke via bash; artifact timing**
- **step43: run smoke via bash; artifact timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step43: build+start Next in CI; run smoke against localhost; artifact timing**
- **step43: measure build+boot+smoke; ignore smoke failure; upload timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step44: upload server.log & smoke.log; keep timing artifact**
