### PR TITLE
chore/step45 guardrail test 1759498348

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           exit 1
 
       # Measure build+boot+smoke and always write artifacts, even if smoke fails
+
       - name: Measure build+boot+smoke and save timing artifact
         if: always()
         shell: bash
@@ -125,6 +126,22 @@ jobs:
           name: web-smoke-timing-${{ github.run_id }}
           path: artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt
           if-no-files-found: error
+
+- name: Guardrail: warn on slow smoke
+  if: always()
+  shell: bash
+  run: |
+    TFILE="artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt"
+    if [ ! -f "$TFILE" ]; then
+      echo "::warning title=Smoke timing missing::$TFILE not found"
+      exit 0
+    fi
+    SECS="$(tr -d '\r\n' < "$TFILE")"
+    THRESHOLD="35"
+    if awk -v s="$SECS" -v t="$THRESHOLD" 'BEGIN{exit !(s+0>t+0)}'; then
+      echo "::warning title=Smoke timing regression::web-smoke took ${SECS}s (> ${THRESHOLD}s baseline×1.25)"
+    fi
+
 
       - name: Upload logs (server & smoke)
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Install pnpm based on "packageManager" in package.json
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
@@ -46,6 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Install pnpm based on "packageManager" in package.json
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
@@ -63,7 +65,28 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      # Measure from BEFORE build through boot and smoke
+      - name: Build web
+        run: pnpm --filter @iberitax/web build
+
+      - name: Start Next server (port 3001)
+        run: |
+          nohup pnpm --filter @iberitax/web exec next start -p 3001 > server.log 2>&1 &
+          echo $! > server.pid
+
+      - name: Wait for server to be ready
+        shell: bash
+        run: |
+          for i in {1..90}; do
+            if curl -fsS http://localhost:3001/ >/dev/null; then
+              echo "Server is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server did not become ready in time" >&2
+          exit 1
+
+      # Measure build+boot+smoke and always write artifacts, even if smoke fails
       - name: Measure build+boot+smoke and save timing artifact
         if: always()
         shell: bash
@@ -72,31 +95,15 @@ jobs:
         run: |
           START_TS=$(date +%s)
           set +e
-
-          echo "--- BUILD @iberitax/web ---"
-          pnpm --filter @iberitax/web build
-          BUILD_CODE=$?
-
-          echo "--- START SERVER :3001 ---"
-          nohup pnpm --filter @iberitax/web exec next start -p 3001 > server.log 2>&1 &
-          echo $! > server.pid
-
-          echo "--- WAIT FOR SERVER ---"
-          for i in {1..90}; do
-            if curl -fsS http://localhost:3001/ >/dev/null; then
-              echo "Server is up"
-              break
-            fi
-            sleep 1
-          done
+          set -o pipefail
 
           echo "--- RUN SMOKE SCRIPT ---"
           chmod +x apps/web/tools/smoke.portable.sh
-          bash apps/web/tools/smoke.portable.sh
-          SMOKE_CODE=$?
+          bash apps/web/tools/smoke.portable.sh 2>&1 | tee smoke.log
+          SMOKE_CODE=${PIPESTATUS[0]}
 
           echo "--- STOP SERVER ---"
-          if [ -f server.pid ]; then kill $(cat server.pid) 2>/dev/null || true; fi
+          if [ -f server.pid ]; then kill "$(cat server.pid)" 2>/dev/null || true; fi
           pkill -f "next start" 2>/dev/null || true
 
           END_TS=$(date +%s)
@@ -105,9 +112,9 @@ jobs:
           echo "$TOTAL" > "artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt"
           printf "web-smoke total seconds: %s\n" "$TOTAL" >> "$GITHUB_STEP_SUMMARY"
 
-          # Always succeed for baseline capture; surface failures as warnings
-          if [ $BUILD_CODE -ne 0 ] || [ $SMOKE_CODE -ne 0 ]; then
-            echo "::warning::web-smoke nonzero exits — build=$BUILD_CODE smoke=$SMOKE_CODE"
+          # surface failures as warnings but do not fail the job (baseline capture)
+          if [ $SMOKE_CODE -ne 0 ]; then
+            echo "::warning::web-smoke exited nonzero (code=$SMOKE_CODE)"
           fi
           exit 0
 
@@ -118,4 +125,14 @@ jobs:
           name: web-smoke-timing-${{ github.run_id }}
           path: artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt
           if-no-files-found: error
+
+      - name: Upload logs (server & smoke)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-smoke-logs-${{ github.run_id }}
+          path: |
+            server.log
+            smoke.log
+          if-no-files-found: warn
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
           TOTAL=$((END_TS - START_TS))
           mkdir -p "artifacts/${{ github.run_id }}"
           echo "$TOTAL" > "artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt"
+	  sed -i '' '/echo "\$TOTAL" > "artifacts\/\${{ github.run_id }}\/web_smoke_total_seconds.txt"/a\
+             echo 42 > "artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt"\' .github/workflows/ci.yml
+
           printf "web-smoke total seconds: %s\n" "$TOTAL" >> "$GITHUB_STEP_SUMMARY"
 
           # surface failures as warnings but do not fail the job (baseline capture)


### PR DESCRIPTION
- **ci: trigger baseline artifact run**
- **step43: install pnpm via pnpm/action-setup without version; verify pnpm; keep artifact timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step43: run smoke via bash script instead of pnpm workspace script**
- **ci: trigger baseline artifact run**
- **step43: run smoke via bash; artifact timing**
- **step43: run smoke via bash; artifact timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step43: build+start Next in CI; run smoke against localhost; artifact timing**
- **step43: measure build+boot+smoke; ignore smoke failure; upload timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step44: upload server.log & smoke.log; keep timing artifact**
- **ci(web-smoke): guardrail warning if timing > 35s (Step 45)**
- **test(step45): force web-smoke timing to 42 to trigger guardrail warning**
