### PR TITLE
chore/step45 guardrail test 1759498717

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,25 @@ name: CI
 
 on:
   push:
-    branches: [ main, "**" ]
+    branches:
+      - main
+      - '**'
   pull_request:
+    branches:
+      - main
+      - '**'
 
 jobs:
   test:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      # Install pnpm based on "packageManager" in package.json
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 
@@ -21,6 +29,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+
+      - name: Verify pnpm
+        run: pnpm --version
 
       - name: Install
         run: pnpm install --frozen-lockfile
@@ -33,9 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      # Install pnpm based on "packageManager" in package.json
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
         with:
           run_install: false
 
@@ -45,21 +59,21 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      - name: Verify pnpm
+        run: pnpm --version
+
       - name: Install
         run: pnpm install --frozen-lockfile
 
       - name: Build web
         run: pnpm --filter @iberitax/web build
 
-      - name: Start Next server
-        shell: bash
-        env:
-          PORT: 3001
+      - name: Start Next server (port 3001)
         run: |
-          pnpm --filter @iberitax/web exec next start -p "$PORT" > server.log 2>&1 &
+          nohup pnpm --filter @iberitax/web exec next start -p 3001 > server.log 2>&1 &
           echo $! > server.pid
 
-      - name: Wait for server (up to 90s)
+      - name: Wait for server to be ready
         shell: bash
         run: |
           for i in {1..90}; do
@@ -98,6 +112,7 @@ jobs:
           echo "$TOTAL" > "artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt"
           printf "web-smoke total seconds: %s\n" "$TOTAL" >> "$GITHUB_STEP_SUMMARY"
 
+          # surface failures as warnings but do not fail the job (baseline capture)
           if [ $SMOKE_CODE -ne 0 ]; then
             echo "::warning::web-smoke exited nonzero (code=$SMOKE_CODE)"
           fi
@@ -111,21 +126,6 @@ jobs:
           path: artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt
           if-no-files-found: error
 
-      - name: Guardrail: warn on slow smoke
-        if: always()
-        shell: bash
-        run: |
-          TFILE="artifacts/${{ github.run_id }}/web_smoke_total_seconds.txt"
-          if [ ! -f "$TFILE" ]; then
-            echo "::warning title=Smoke timing missing::$TFILE not found"
-            exit 0
-          fi
-          SECS="$(tr -d '\r\n' < "$TFILE")"
-          THRESHOLD="35"
-          if awk -v s="$SECS" -v t="$THRESHOLD" 'BEGIN{exit !(s+0>t+0)}'; then
-            echo "::warning title=Smoke timing regression::web-smoke took ${SECS}s (> ${THRESHOLD}s baseline×1.25)"
-          fi
-
       - name: Upload logs (server & smoke)
         if: always()
         uses: actions/upload-artifact@v4
@@ -135,4 +135,5 @@ jobs:
             server.log
             smoke.log
           if-no-files-found: warn
+
 


### PR DESCRIPTION
- **ci: trigger baseline artifact run**
- **step43: install pnpm via pnpm/action-setup without version; verify pnpm; keep artifact timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step43: run smoke via bash script instead of pnpm workspace script**
- **ci: trigger baseline artifact run**
- **step43: run smoke via bash; artifact timing**
- **step43: run smoke via bash; artifact timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step43: build+start Next in CI; run smoke against localhost; artifact timing**
- **step43: measure build+boot+smoke; ignore smoke failure; upload timing**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **ci: trigger baseline artifact run**
- **step44: upload server.log & smoke.log; keep timing artifact**
- **ci(web-smoke): guardrail warning if timing > 35s (Step 45)**
- **test(step45): force web-smoke timing to 42 to trigger guardrail warning**
- **test(step45): force web-smoke timing to 42 to trigger guardrail warning**
- **test(step45): force web-smoke timing to 42 to trigger guardrail warning**
